### PR TITLE
DPE-781 Run integration tests for passed lint/unit tests only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,8 @@ jobs:
 
   integration-test:
     name: Integration tests (microk8s)
+    needs:
+      - lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Avoid a long-running integration test in case of failing gatekeeping tests. It will slightly increase the complete tests scope runtime but will save (a lot?) of electricity/money for Canonical as often new pull requests have some initial typos/issues to be polished.

# Issue
Decrease tests execution cost in case if lint tests are not happy.

# Solution
Run integration tests after successfully finished lintian tests only.

# Context
GitHub Actions.

# Testing
Check this pull-request tests (GitHub actions) order. Lint tests should go first.

# Release Notes
Run integration tests for passed lint/unit tests only