### PR TITLE
mysql-vm tls enabled bundle

### DIFF
--- a/releases/latest/mysql-bundle.yaml
+++ b/releases/latest/mysql-bundle.yaml
@@ -3,20 +3,31 @@ applications:
     channel: latest/edge
     charm: mysql
     constraints: arch=amd64
-    num_units: 1
-    revision: 80
+    num_units: 3
+    revision: 81
     to:
-    - '0'
+      - "0"
   mysql-router:
     channel: dpe/edge
     charm: mysql-router
-    revision: 42
+    revision: 44
+  tls-certificates-operator:
+    channel: latest/edge
+    charm: tls-certificates-operator
+    constraints: arch=amd64
+    revision: 15
+    scale: 1
+    options:
+      ca-common-name: canonical
+      generate-self-signed-certificates: true
 machines:
-  '0':
+  "0":
     constraints: arch=amd64
 name: mysql-bundle
 relations:
-- - mysql:database
-  - mysql-router:backend-database
+  - - mysql:database
+    - mysql-router:backend-database
+  - - mysql:certificates
+    - tls-certificates-operator:certificates
 series: focal
 type: bundle


### PR DESCRIPTION
# Issue

TLS must be bundle default deployment.

# Solution

Add TLS to bundle.

# To fix
- add tests
- allow single unit mysql after fix for ([bug #59](https://github.com/canonical/mysql-operator/issues/59))
