### PR TITLE
Bump actions/checkout@v2->v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: python3 -m pip install tox
       - name: Run linters

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install dependencies


### PR DESCRIPTION
This should get rid of warning on GH Action:

> Node.js 12 actions are deprecated. For more information see:
> https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
> Please update the following actions to use Node.js 16: actions/checkout@v2

# Issue
Just a warning fix to keep the house clean.


# Solution
Update GH Action actions/checkout from v2 to v3


# Context
There is a warning on GH Action to be fixed.


# Testing
No more warnings on the repos with v3.


# Release Notes
Bump actions/checkout@v2->v3