### PR TITLE
Fix tox v4 support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ deps =
     isort
     codespell
 commands =
-    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
+    codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox \
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/LICENSE
     # pflake8 wrapper supports config from pyproject.toml


### PR DESCRIPTION
'codespell {toxinidir}/.' worked well in tox v3, but breaks in tox v4. 'codespell {toxinidir}/.' works for both v3 and v4.

# Issue
The conti tox.init was incompatible with tox v4: 'codespell --skip' didn't work.

# Solution
Remove unnecessary "./":
```
lint: commands[0]> codespell /home/runner/work/mysql-bundle/mysql-bundle/. --skip /home/runner/work/mysql-bundle/mysql-bundle/.git --skip /home/runner/work/mysql-bundle/mysql-bundle/.tox --skip /home/runner/work/mysql-bundle/mysql-bundle/build --skip /home/runner/work/mysql-bundle/mysql-bundle/lib --skip /home/runner/work/mysql-bundle/mysql-bundle/venv --skip /home/runner/work/mysql-bundle/mysql-bundle/.mypy_cache --skip /home/runner/work/mysql-bundle/mysql-bundle/LICENSE
/home/runner/work/mysql-bundle/mysql-bundle/./.tox/lint/lib/python3.10/site-packages/mccabe.py:2: Ned ==> Need, End
/home/runner/work/mysql-bundle/mysql-bundle/./.tox/lint/lib/python3.10/site-packages/pycodestyle.py:1[5](https://github.com/canonical/mysql-bundle/actions/runs/3642676739/jobs/6150104942#step:4:6)[7](https://github.com/canonical/mysql-bundle/actions/runs/3642676739/jobs/6150104942#step:4:8)0: alph ==> alpha
```

# Testing
Tested by Carl in https://github.com/canonical/template-operator/pull/42

# Release Notes
Fix tox.ini to support tox v4.