### PR TITLE
Fix tox.init to test while repo for lint check + "tox -e fmt"

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,8 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+"""The pytest fixtures to support '--bundle' cmd option for CI/CD."""
+
 
 def pytest_addoption(parser):
     """Defines pytest parsers."""

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist = lint, unit
 
 [vars]
 tst_path = {toxinidir}/tests/
-all_path = {[vars]tst_path}
+all_path = {toxinidir}
 
 [testenv]
 setenv =

--- a/update_bundle.py
+++ b/update_bundle.py
@@ -2,6 +2,8 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+"""The script to update Juju bundle.yaml on CI/CD."""
+
 import logging
 import subprocess
 import sys


### PR DESCRIPTION
Otherwise "tox -e lint" was testing tests/* files only.

# Issue
Lint was testing "tests/*" files only.

# Solution
Test the while repo with Lint.

# Context
The tox.ini file was corrected + all code reformatted and lint warnings fixed.

# Testing
Tested locally using: "tox -e lint" + "tox -e fmt"

# Release Notes
Fix tox.ini to call Lint tests on the whole repository codebase.