### PR TITLE
Simplify bundle config

### DIFF
--- a/releases/latest/mysql-bundle.yaml
+++ b/releases/latest/mysql-bundle.yaml
@@ -2,34 +2,27 @@ applications:
   mysql:
     channel: latest/edge
     charm: mysql
-    constraints: arch=amd64
     num_units: 3
     revision: 121
-    to:
-    - '0'
   mysql-router:
     channel: dpe/edge
     charm: mysql-router
     revision: 63
-  tls-certificates-operator:
+  tls-certificates:
     channel: latest/edge
     charm: tls-certificates-operator
-    constraints: arch=amd64
+    num_units: 1
     options:
       ca-common-name: canonical
       generate-self-signed-certificates: true
     revision: 22
-    scale: 1
-    to:
-    - '0'
-machines:
-  '0':
-    constraints: arch=amd64
+description: Charmed MySQL bundle
+issues: https://github.com/canonical/mysql-bundle/issues
 name: mysql-bundle
 relations:
 - - mysql:database
   - mysql-router:backend-database
 - - mysql:certificates
-  - tls-certificates-operator:certificates
-series: focal
+  - tls-certificates:certificates
+source: https://github.com/canonical/mysql-bundle
 type: bundle

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8==5.0.4 # Pin due to compatibility issues with v6
+    flake8
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ commands =
 [testenv:integration]
 description = Run all integration tests
 deps =
-    juju=2.9.38.1
+    juju==2.9.38.1
     pytest
     pytest-operator>0.17.0
     -r {tox_root}/requirements.txt

--- a/update_bundle.py
+++ b/update_bundle.py
@@ -43,15 +43,16 @@ def update_bundle(bundle_path):
     """Updates a bundle's revision number."""
     bundle_data = yaml.safe_load(Path(bundle_path).read_text())
 
-    for applications in bundle_data["applications"]:
-        if series := bundle_data["applications"][applications].get("series"):
+    for juju_app in bundle_data["applications"]:
+        application = bundle_data["applications"][juju_app]["charm"]
+        if series := bundle_data["applications"][juju_app].get("series"):
             ubuntu_version = subprocess.check_output(
                 ["ubuntu-distro-info", "--series", series, "--release"], encoding="utf-8"
             ).split(" ")[0]
         else:
             ubuntu_version = None
-        bundle_data["applications"][applications]["revision"] = fetch_revision(
-            applications, bundle_data["applications"][applications]["channel"], ubuntu_version
+        bundle_data["applications"][juju_app]["revision"] = fetch_revision(
+            application, bundle_data["applications"][juju_app]["channel"], ubuntu_version
         )
 
     with open(bundle_path, "w") as bundle:


### PR DESCRIPTION
## Issue
The previous bundle config looks incredibly complex and therefor buggy,
e.g. we were installing mysql/0 and tls-operator on the same lxc machine.

## Solution
* Remove confusing mysql and tls installation in the same machine '0'
* Remove unnecessary and confusing 'serial'
* Remove currently unnecessary constraints
* Add issues, source and update description
* Simplify wording and layout
* Improve update_bundle.py to use Juju app aliases