### PR TITLE
Restore field 'series' to make 'charmcraft upload' happy

### DIFF
--- a/releases/latest/mysql-bundle.yaml
+++ b/releases/latest/mysql-bundle.yaml
@@ -8,6 +8,7 @@ applications:
     channel: dpe/edge
     charm: mysql-router
     revision: 63
+    series: focal
   tls-certificates:
     channel: latest/edge
     charm: tls-certificates-operator
@@ -24,5 +25,6 @@ relations:
   - mysql-router:backend-database
 - - mysql:certificates
   - tls-certificates:certificates
+series: jammy
 source: https://github.com/canonical/mysql-bundle
 type: bundle


### PR DESCRIPTION
## Issue
The previous commit introduced regression on GitHub CI/CD,
the 'charmcraft upload' is blaming for missing series
(it was recently removed as not necessary for juju 2.9 CLI):

> charmcraft upload ./build/*.zip --name mysql-bundle --release=latest/edge
> ...
> 'code': 'review-error',
> 'message': 'missing required field(s): series or bundle'},
> 'status': 'rejected',

## Solution
Use series `jammy` by default, but lock `mysql-router` in `focal` as no `jammy` currently being built and published.