### PR TITLE
DPE-1656 Limit tests RAM usage by every unit/container to 1Gb

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
+          bootstrap-options: "--constraints mem=1G"
       - name: Run integration bundle test
         run: tox run -e integration -- --junit-xml=pytest_report.xml
       - name: 'Foresight: Collect test results'


### PR DESCRIPTION
## Issue
Often and strange tests crashes on GH runner while all is OK on localhost.

## Solution
GH Runners have 8GB RAM only. We are launching 1-2 MySQL clusters with three units each and allocating 50% for innodb_buffer_pull_size. OOM is an often trouble in this case.