### PR TITLE
Revert "Add Foresight actions to CI (#35)"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: 'Foresight: Collect workflow telemetry'
-        uses: runforesight/foresight-workflow-kit-action@v1
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install tox
@@ -36,8 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: 'Foresight: Collect workflow telemetry'
-        uses: runforesight/foresight-workflow-kit-action@v1
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup operator environment
@@ -45,11 +41,4 @@ jobs:
         with:
           provider: lxd
       - name: Run integration bundle test
-        run: tox run -e integration -- --junit-xml=pytest_report.xml
-      - name: 'Foresight: Collect test results'
-        uses: runforesight/foresight-test-kit-action@v1
-        if: ${{ success() || failure() }}
-        with:
-          test_framework: PYTEST
-          test_format: JUNIT
-          test_path: pytest_report.xml
+        run: tox -e integration

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,8 +18,6 @@ jobs:
     env:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}
     steps:
-      - name: 'Foresight: Collect workflow telemetry'
-        uses: runforesight/foresight-workflow-kit-action@v1
       - name: Checkout
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This reverts commit ed20832c347524037b33252361681e0a4016f9f1.

## Issue
https://github.com/canonical/data-platform-workflows/issues/37

## Solution
