### PR TITLE
DPE-2210 Switch all test from focal to jammy

### DIFF
--- a/releases/latest/mysql-bundle.yaml
+++ b/releases/latest/mysql-bundle.yaml
@@ -8,7 +8,7 @@ applications:
     channel: dpe/edge
     charm: mysql-router
     revision: 76
-    series: focal
+    series: jammy
   tls-certificates:
     channel: latest/edge
     charm: tls-certificates-operator

--- a/releases/latest/mysql-bundle.yaml
+++ b/releases/latest/mysql-bundle.yaml
@@ -3,20 +3,19 @@ applications:
     channel: 8.0/edge
     charm: mysql
     num_units: 3
-    revision: 164
+    revision: 167
   mysql-router:
     channel: dpe/edge
     charm: mysql-router
-    revision: 76
-    series: jammy
+    revision: 85
   tls-certificates:
-    channel: latest/edge
+    channel: latest/stable
     charm: tls-certificates-operator
     num_units: 1
     options:
       ca-common-name: canonical
       generate-self-signed-certificates: true
-    revision: 27
+    revision: 22
 description: Charmed MySQL bundle
 issues: https://github.com/canonical/mysql-bundle/issues
 name: mysql-bundle

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -23,7 +23,7 @@ async def test_deploy_bundle(ops_test: OpsTest) -> None:
             APPLICATION_APP,
             channel="edge",
             application_name=APPLICATION_APP,
-            series="focal",
+            series="jammy",
             num_units=3,
         )
 

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -45,5 +45,5 @@ async def test_deploy_bundle(ops_test: OpsTest) -> None:
         await ops_test.model.wait_for_idle(
             apps=[MYSQL_APP, ROUTER_APP, TLS_APP, APPLICATION_APP],
             status="active",
-            timeout=5 * 60,
+            timeout=15 * 60,
         )


### PR DESCRIPTION
## Issue

We used to test focal here because charm CI/CD didn't support several series. It has been fixed long time ago.

## Solution

The mysql-router is now available for both jammy and focal, let's test default series for all compoment (as latest LTS is 22.04 jammy).
