### PR TITLE
Add workflow badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Canonical Distribution of MySQL + MySQLRouter
+[![Charmhub](https://charmhub.io/mysql-bundle/badge.svg)](https://charmhub.io/mysql-bundle)
+[![Release](https://github.com/canonical/mysql-bundle/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/mysql-bundle/actions/workflows/release.yaml)
+[![Tests](https://github.com/canonical/mysql-bundle/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/canonical/mysql-bundle/actions/workflows/ci.yaml)
 
 Welcome to the Canonical Distribution of MySQL + MySQLRouter.
 


### PR DESCRIPTION
## Issue
This repo's status is not displayed in the [Charm Engineering Releases](https://releases.juju.is/?team=Data) overview.

## Solution
Added workflow badges for 
* CharmHub Badge
* Release
* Tests