### PR TITLE
[DPE-5382] Bump `Update Bundle` workflow to v23.0.2

### DIFF
--- a/.github/workflows/update_bundle.yaml
+++ b/.github/workflows/update_bundle.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-bundle:
     name: Update bundle
-    uses: canonical/data-platform-workflows/.github/workflows/update_bundle.yaml@v22.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/_update_bundle.yaml@v23.0.1
     with:
       path-to-bundle-file: releases/latest/mysql-bundle.yaml
       reviewers: canonical/data-platform-mysql

--- a/.github/workflows/update_bundle.yaml
+++ b/.github/workflows/update_bundle.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-bundle:
     name: Update bundle
-    uses: canonical/data-platform-workflows/.github/workflows/_update_bundle.yaml@v23.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/_update_bundle.yaml@v23.0.2
     with:
       path-to-bundle-file: releases/latest/mysql-bundle.yaml
       reviewers: canonical/data-platform-mysql


### PR DESCRIPTION
This new version will bring snaps version pinning to the bundle, see https://github.com/canonical/data-platform-workflows/pull/239 for more info. Example run result can be seen here: https://github.com/canonical/mysql-bundle/commit/612d5316706cadc45073290c1a55034617ccadca

Note: This new workflow is considered experimental and only meant for use in SQL bundles. Old one was deleted on https://github.com/canonical/data-platform-workflows/pull/238