### PR TITLE
[DPE-6042] Make tox commands resilient to white-space paths

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ no_package = True
 env_list = lint, unit
 
 [vars]
-tests_path = {tox_root}/tests
+tests_path = "{tox_root}/tests"
 all_path = {[vars]tests_path}
 
 [testenv]


### PR DESCRIPTION
This PR fixes [tox.ini](https://github.com/canonical/mysql-bundle/blob/main/tox.ini) commands when the repository is cloned on a white-space containing path.

### How to reproduce:
```shell
$ mkdir -p "Projects/Canonical/Data Platform/MySQL"
$ cd "Projects/Canonical/Data Platform/MySQL"
$ git clone https://github.com/canonical/mysql-bundle
$ cd mysql-bundle
$ tox run -e format
> ...
> /Users/<USERNAME>/Projects/Canonical/Data:1:1: E902 No such file or directory (os error 2)
> Platform/MySQL/mysql-bundle/src:1:1: E902 No such file or directory (os error 2)
> Platform/MySQL/mysql-bundle/tests:1:1: E902 No such file or directory (os error 2)
```